### PR TITLE
IAT-2583

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -15,14 +15,8 @@
 spring:
   datasource:
     url: "jdbc:postgresql://localhost:5432/iat"
-    username: "${DB_USER}"
+    username: "iat_admin"
     password: "${DB_PASSWORD}"
-
-flyway:
-  enabled: true
-  url: "jdbc:postgresql://localhost:5432/iat"
-  user: "iat_admin"
-  password: "${DB_PASSWORD}"
 
 ---
 spring:
@@ -32,7 +26,6 @@ spring:
 
 flyway:
   enabled: false
-  url: "jdbc:postgresql://imrt-qa-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com:5432/iat"
 
 ---
 spring:
@@ -42,4 +35,3 @@ spring:
 
 flyway:
   enabled: false
-  url: "jdbc:postgresql:imrt-db-uat-aurora.cjqp2fdamfoh.us-east-2.rds.amazonaws.com"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url:
-    username:
-    password:
+    url: "jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.schema:iat}"
+    username: "${db.user:iat_admin}"
+    password: "${db.password}"
 
 flyway:
   enabled: true


### PR DESCRIPTION
- Added place holder values and default values in the classpath application.yml
- Simplified the root application.yml

The placeholders in the classpath file does simplify running it.  Locally when running it has not become `java -jar ./AP_IAT_Schema.jar` given us developers have an env var for the db password set.  And when running it for non-local environments we just need the host and password `java -jar ./AP_IAT_Schema.jar --db.host="imrt-qa-db.cjqp2fdamfoh.us-east-2.rds.amazonaws.com" --db.password="1234"`


