### PR TITLE
Feature/iat 3155

### DIFF
--- a/src/main/resources/db/migration/V12__iat_ddl.sql
+++ b/src/main/resources/db/migration/V12__iat_ddl.sql
@@ -1,0 +1,32 @@
+--
+-- https://jira.fairwaytech.com/browse/IAT-3155
+--
+
+-- item history
+CREATE TABLE IF NOT EXISTS item_history (
+  id                        UUID        NOT NULL,
+
+  item_id                   TEXT        NOT NULL CHECK (char_length(item_id)  <= 255),
+
+  event_type                TEXT        NOT NULL CHECK (char_length(event_type)  <= 255),
+
+  item_commit_id            UUID,
+  branch_commit_id          UUID,
+
+  content_zip_version_id    TEXT        CHECK (char_length(content_zip_version_id)  <= 255),
+
+  commit_date               TIMESTAMPTZ NOT NULL,
+  commit_by                 VARCHAR     NOT NULL,
+
+  created_date              TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+  created_by                VARCHAR     NOT NULL,
+  updated_date              TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+  updated_by                VARCHAR     NOT NULL,
+
+  CONSTRAINT pk_item_history PRIMARY KEY (id)
+);
+
+-- flywayClean deletes all user privileges, so we will set them here
+-- Assumes that iat user has already been created in the database
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES in schema public to "iat";
+GRANT SELECT, UPDATE ON ALL SEQUENCES in schema public to "iat";

--- a/src/main/resources/db/migration/V12__iat_ddl.sql
+++ b/src/main/resources/db/migration/V12__iat_ddl.sql
@@ -5,25 +5,19 @@
 -- item history
 CREATE TABLE IF NOT EXISTS item_history (
   id                    UUID        NOT NULL,
-
   item_id               TEXT        NOT NULL CHECK (char_length(item_id)  <= 255),
-
   item_commit_id        UUID,
   branch_commit_id      UUID,
-
   content_version_id    TEXT        CHECK (char_length(content_version_id)  <= 255),
-
-  commit_by             VARCHAR     NOT NULL,
+  commit_by             TEXT        CHECK (char_length(content_version_id)  <= 255),
   commit_date           TIMESTAMPTZ NOT NULL,
   commit_message        TEXT        NOT NULL,
-
   created_date          TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
-
   CONSTRAINT pk_item_history PRIMARY KEY (id),
   UNIQUE (item_id, item_commit_id, commit_date)
 );
 
--- flywayClean deletes all user privileges, so we will set them here
+-- Adding a table requires these statements to be run
 -- Assumes that iat user has already been created in the database
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES in schema public to "iat";
 GRANT SELECT, UPDATE ON ALL SEQUENCES in schema public to "iat";

--- a/src/main/resources/db/migration/V12__iat_ddl.sql
+++ b/src/main/resources/db/migration/V12__iat_ddl.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS item_history (
   item_commit_id        UUID,
   branch_commit_id      UUID,
   content_version_id    TEXT        CHECK (char_length(content_version_id)  <= 255),
-  commit_by             TEXT        CHECK (char_length(content_version_id)  <= 255),
+  commit_by             TEXT        CHECK (char_length(commit_by)  <= 255),
   commit_date           TIMESTAMPTZ NOT NULL,
   commit_message        TEXT        NOT NULL,
   created_date          TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,

--- a/src/main/resources/db/migration/V12__iat_ddl.sql
+++ b/src/main/resources/db/migration/V12__iat_ddl.sql
@@ -4,26 +4,23 @@
 
 -- item history
 CREATE TABLE IF NOT EXISTS item_history (
-  id                        UUID        NOT NULL,
+  id                    UUID        NOT NULL,
 
-  item_id                   TEXT        NOT NULL CHECK (char_length(item_id)  <= 255),
+  item_id               TEXT        NOT NULL CHECK (char_length(item_id)  <= 255),
 
-  event_type                TEXT        NOT NULL CHECK (char_length(event_type)  <= 255),
+  item_commit_id        UUID,
+  branch_commit_id      UUID,
 
-  item_commit_id            UUID,
-  branch_commit_id          UUID,
+  content_version_id    TEXT        CHECK (char_length(content_version_id)  <= 255),
 
-  content_zip_version_id    TEXT        CHECK (char_length(content_zip_version_id)  <= 255),
+  commit_by             VARCHAR     NOT NULL,
+  commit_date           TIMESTAMPTZ NOT NULL,
+  commit_message        TEXT        NOT NULL,
 
-  commit_date               TIMESTAMPTZ NOT NULL,
-  commit_by                 VARCHAR     NOT NULL,
+  created_date          TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
 
-  created_date              TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
-  created_by                VARCHAR     NOT NULL,
-  updated_date              TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
-  updated_by                VARCHAR     NOT NULL,
-
-  CONSTRAINT pk_item_history PRIMARY KEY (id)
+  CONSTRAINT pk_item_history PRIMARY KEY (id),
+  UNIQUE (item_id, item_commit_id, commit_date)
 );
 
 -- flywayClean deletes all user privileges, so we will set them here


### PR DESCRIPTION
I'm using TEXT over VARCHAR.  They are mostly the same but an advantage with TEXT in combination with a size CHECK function is that it's easy to increase the size on the fly.

This follows the item and item_sync table designs where we are having the service generate a UUID for the PK for the record. 