### PR TITLE
IAT-3306: add migration for new permission

### DIFF
--- a/src/main/resources/db/migration/V21__iat_ddl.sql
+++ b/src/main/resources/db/migration/V21__iat_ddl.sql
@@ -1,0 +1,21 @@
+INSERT INTO tims_permission(
+    id,
+    code,
+    label,
+    description,
+    permission_order,
+    permission_category_id,
+    is_workflow_restricted,
+    created_by,
+    updated_by)
+VALUES (
+    NEXTVAL('tims_permission_seq'),
+    'can_edit_sa_text_editor_type',
+    'Edit SA Text Editor Type',
+    'Can override the default short answer item text editor',
+    (SELECT MAX(permission_order) FROM tims_permission) + 1,
+    (SELECT id FROM tims_permission_category WHERE code = 'Item Editing'),
+    false,
+    COALESCE((SELECT MIN(id) FROM tims_user), 1),
+    COALESCE((SELECT MIN(id) FROM tims_user), 1)
+);


### PR DESCRIPTION
[IAT-3306](https://smarterbalanced.atlassian.net/browse/IAT-3306):  Rich Text Editor for TIMS Short Answer Items

* Add new record to `tims_permission` table to describe the privilege necessary to override the default text editor type for an SA item.