### PR TITLE
Enforce workflow status restriction on SA content text editor override

### DIFF
--- a/src/main/resources/db/migration/V24__iat_ddl.sql
+++ b/src/main/resources/db/migration/V24__iat_ddl.sql
@@ -1,0 +1,34 @@
+DO $$
+DECLARE
+    roleId integer;
+    permissionId integer;
+    createdBy integer;
+BEGIN
+    SELECT COALESCE(MIN(id), 1) FROM tims_role INTO roleId;
+    SELECT id FROM tims_permission WHERE code = 'can_edit_sa_text_editor_type' INTO permissionId;
+    SELECT COALESCE(MIN(id), 1) FROM tims_user INTO createdBy;
+
+    UPDATE
+        tims_permission
+    SET
+        is_workflow_restricted = true
+    WHERE
+        id = permissionId;
+
+    INSERT INTO tims_role_permission_workflow_status(
+        role_id,
+        permission_id,
+        workflow_status_code,
+        created_by,
+        created_date)
+    SELECT
+        roleId,
+        permissionId,
+        ws.code,
+        createdBy,
+        CURRENT_TIMESTAMP
+    FROM
+        workflow_status ws
+    ON CONFLICT(role_id, permission_id, workflow_status_code)
+        DO NOTHING;
+END $$;


### PR DESCRIPTION
## Overview
This migration will set up the `can_edit_sa_text_editor_type` permission to be restricted to various workflow statuses.

* This PR is directly related to [this AP_ItemAuthoringTool PR](https://github.com/SmarterApp/AP_ItemAuthoringTool/pull/737).

## Additional Details
After discussion with @millerts , it was determined that the text editor override for SA items could possibly be restricted to certain workflow statuses (like many other editable parts of the application already are).  There isn't a JIRA specifically associated with this effort.