### PR TITLE
IAT-3628: Update IAT DB to grant the iat user certain privileges on t…

### DIFF
--- a/src/main/resources/db/migration/V37__iat_ddl.sql
+++ b/src/main/resources/db/migration/V37__iat_ddl.sql
@@ -1,0 +1,9 @@
+-- IAT-3628: Update IAT DB to grant the iat user certain privileges on the public schema
+
+ALTER DEFAULT PRIVILEGES
+    IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO iat;
+
+ALTER DEFAULT PRIVILEGES
+    IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO iat;


### PR DESCRIPTION
…he public schema.  These changes fix us needing to always run grants in our scripts when we create a table/sequence.